### PR TITLE
Avoid linebreak before link indicators

### DIFF
--- a/lib.typ
+++ b/lib.typ
@@ -137,7 +137,9 @@
     it
     // Workaround for ctheorems package so that its labels keep the default link styling.
     if external-link-circle and type(it.dest) != label  {
+      sym.wj
       h(1.6pt)
+      sym.wj
       super(box(height: 3.8pt, circle(radius: 1.2pt, stroke: 0.7pt + rgb("#993333"))))
     }
   }


### PR DESCRIPTION
It seems that otherwise, it is possible for a line break to occur just between the link text and the circle.

According to https://github.com/typst/typst/discussions/4372, adding the Unicode word join character is the way to forbid breaking at a specific breakpoint. I'm not totally sure both of these are needed: For the specific link where I found this issue, the character in the second position was sufficient to avoid the line break.