### PR TITLE
Add settings to page numbers and footer

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ This template exports the `ilm` function with the following named arguments:
 | `figure-index` | `(enabled: false, title: "Index of Figures")` | [dictionary] | Setting this to `true` will display an index of image figures at the end of the document. |
 | `table-index` | `(enabled: false, title: "Index of Tables")` | [dictionary] | Setting this to `true` will display an index of table figures at the end of the document. |
 | `listing-index` | `(enabled: false, title: "Index of Listings")` | [dictionary] | Setting this to `true` will display an index of listing (code block) figures at the end of the document. |
+| `footer` | `(number-on-alternating-sides: true, fixed-side-right: true, repeat-chapter-title: true)` | [dictionary] | Configures footer printing. Setting `number-on-alternating-sides` to `false` will print all page numbers on the same side, right if `fixed-side-right` is true, else left. `repeat-chapter-title` configures if the chapter title is printed in the footer line. |
 
 The above table gives you a _brief description_ of the different options that you can
 choose to customize the template. For a detailed explanation of these options, see the

--- a/lib.typ
+++ b/lib.typ
@@ -82,6 +82,15 @@
     enabled: false,
     title: "",
   ),
+  // Page footer configuration
+  footer: (
+    // Alternate the page indicator on left and right side (like a book)
+    number-on-alternating-sides: true,
+    // if alternating is off, this chooses the side to print numbers on
+    fixed-side-right: true,
+    // Repeat chapter title
+    repeat-chapter-title: true,
+  ),
 
   // The content of your work.
   body,
@@ -172,9 +181,18 @@
     // Get current page number.
     let i = counter(page).at(here()).first()
 
+    let number-on-alternating-sides = footer.at("number-on-alternating-sides", default: true)
+    let fixed-side-right = footer.at("fixed-side-right", default: true)
+    let repeat-chapter-title = footer.at("repeat-chapter-title", default: true)
+
     // Align right for even pages and left for odd.
-    let is-odd = calc.odd(i)
-    let aln = if is-odd {
+    let on-right-side = if number-on-alternating-sides {
+      calc.odd(i)
+    } else {
+      fixed-side-right
+    }
+
+    let aln = if on-right-side {
       right
     } else {
       left
@@ -191,9 +209,13 @@
     if before.len() > 0 {
       let current = before.last()
       let gap = 1.75em
-      let chapter = upper(text(size: 0.68em, current.body))
+      let chapter = if repeat-chapter-title {
+        upper(text(size: 0.68em, current.body))
+      } else {
+        ""
+      }
       if current.numbering != none {
-        if is-odd {
+        if on-right-side {
           align(aln)[#chapter #h(gap) #i]
         } else {
           align(aln)[#i #h(gap) #chapter]

--- a/template/main.typ
+++ b/template/main.typ
@@ -182,11 +182,25 @@ The template also displays an index of figures (images), tables, and listings (c
 The `title` option can be omitted as it is optional and will default to predefined values.
 
 == Footer
-If a page does not begin with a chapter then the chapter's name, to which the current section belongs to, is shown in the footer.
+```typst
+#show: ilm.with(
+  footer: (
+    number-on-alternating-sides: true,
+    fixed-side-right: true,
+    repeat-chapter-title: true,
+  ),
+)
+```
+
+All values will use the default value if not passed to the dictionary.
+
+If a page does not begin with a chapter then the chapter's name, to which the current section belongs to, is shown in the footer, unless `repeat-chapter-title` is set to `false`.
 
 Look at the page numbering for the current page down below. It will show "#upper[Layout]" next to the page number because the current subheading _Footer_ is part of the _Layout_ chapter.
 
 When we say chapter, we mean the the first-level or top-level heading which is defined using a single equals sign (`=`).
+
+For reports, the alternating printing of page numbers at the left and right can be disabled by setting `number-on-alternating-side` to `false`. The resulting side is defined by `fixed-side-right` (`true` for right, `false` for left).
 
 = Text
 Typst defaults to English for the language of the text. If you are writing in a different language then you need to define you language before the 'Ilm template is loaded, i.e. before the `#show: ilm.with()` like so:


### PR DESCRIPTION
Allows disabling the alternation of pages from left and right, so it can be used easier for reports instead of books.
Also allows to disable the repeating of chapter titles.