### PR TITLE
Update appendix functionality

### DIFF
--- a/lib.typ
+++ b/lib.typ
@@ -1,3 +1,5 @@
+#import "@preview/numbly:0.1.0": numbly
+
 // Workaround for the lack of an `std` scope.
 #let std-bibliography = bibliography
 #let std-smallcaps = smallcaps
@@ -38,13 +40,6 @@
   // Set this to `none`, if you want to disable the table of contents.
   // More info: https://typst.app/docs/reference/model/outline/
   table-of-contents: outline(),
-  // Display an appendix after the body but before the bibliography.
-  appendix: (
-    enabled: false,
-    title: "",
-    heading-numbering-format: "",
-    body: none,
-  ),
   // The result of a call to the `bibliography` function or `none`.
   // Example: bibliography("refs.bib")
   // More info: https://typst.app/docs/reference/model/bibliography/
@@ -226,29 +221,6 @@
     body
   }
 
-  // Display appendix before the bibliography.
-  if appendix.enabled {
-    pagebreak()
-    heading(level: 1)[#appendix.at("title", default: "Appendix")]
-
-    // For heading prefixes in the appendix, the standard convention is A.1.1.
-    let num-fmt = appendix.at("heading-numbering-format", default: "A.1.1.")
-
-    counter(heading).update(0)
-    set heading(
-      outlined: false,
-      numbering: (..nums) => {
-        let vals = nums.pos()
-        if vals.len() > 0 {
-          let v = vals.slice(0)
-          return numbering(num-fmt, ..v)
-        }
-      },
-    )
-
-    appendix.body
-  }
-
   // Display bibliography.
   if bibliography != none {
     pagebreak()
@@ -305,4 +277,30 @@
     stroke: (y: 0.5pt + stroke-color),
     body,
   )
+}
+
+#let appendix(
+  title: "Appendix",
+  body,
+) = {
+  pagebreak()
+  align(center)[
+    #heading( // Appendix general title
+      level: 1,
+      numbering: none, // no prefix
+      title,
+    )
+  ]
+  counter(heading).update(0) // Reset the heading counter
+  set heading(
+    offset: 1, // Scramble everything in the appendix environment under the general title
+    numbering: numbly(
+      "", // Appendix general title, no prefix
+      "{2:A}.", // Actual First level
+      "{2:A}.{3}.", // Lower levels use arabic numerals
+      "{2:A}.{3}.{4}.",
+    )
+  )
+
+  body
 }

--- a/template/main.typ
+++ b/template/main.typ
@@ -1,4 +1,4 @@
-#import "@preview/ilm:1.4.1": *
+#import "../lib.typ": *
 
 #set text(lang: "en")
 
@@ -115,35 +115,33 @@ By default, the template will insert a #link("https://typst.app/docs/reference/l
 ```
 
 == Appendices
-The template can display different appendix, if you enable and define it:
+You can invoke the appendices section by:
 
 ```typst
-#show: ilm.with(
-  appendix: (
-    enabled: true,
-    title: "Appendix", // optional
-    heading-numbering-format: "A.1.1.", // optional
-    body: [
-      = First Appendix
-      = Second Appendix
-    ],
-  ),
+#show: appendix.with(
+  title: "附录",
 )
+= First Appendix
+= Second Appendix
 ```
 
-The `title` and `heading-numbering-format` options can be omitted as they are optional and will default to predefined values.
+Anything that you write after this statement will be shown in the appendices section.
+
+The `title` parameter can be omitted as it is optional and will be set to default value `Appendix`:
+
+```typst
+#show: appendix
+= First Appendix
+= Second Appendix
+```
 
 #emoji.fire Tip: if your appendix is quite long then you can define it in a separate file and import it in the template definition like so:
 
 ```typst
-#show: ilm.with(
-  appendix: (
-    enabled: true,
-    // Assuming your file is called `appendix.typ` and is
-    // located in the same directory as your main Typst file.
-    body: [#include "appendix.typ"],
-  ),
-)
+#show: appendix
+// Assuming your file is called `appendix.typ` and is
+// located in the same directory as your main Typst file.
+#include "appendix.typ"
 ```
 
 == Bibliography


### PR DESCRIPTION
Added appendix function in lib.typ, which allows a more elegant & intuitive way to invoke the appendix environment in the mainmatter.
```
#show: appendix
```

As discussed in
https://github.com/talal/ilm/issues/14#issuecomment-2507787173
It's much better to use a `\appendix` like command in latex than cramping a large content block in a function argument.

This approach is inspired by
https://github.com/typst/typst/discussions/4031

The only change in appearance is that chapters in the appendix will be shown in the table of contents, degraded one level (chapters -> sections, sections -> subsections, etc.), and listed under a general appendix title assigned by the user.
```
- Previous Chapters
- Appendix
  A. First Appendix
  B. Second Appendix
- Biblography
```

Updated relavent documentations