### PR TITLE
allow for disabling title page by setting title to []

### DIFF
--- a/lib.typ
+++ b/lib.typ
@@ -105,31 +105,33 @@
   )
 
   // Cover page.
-  page(
-    align(
-      left + horizon,
-      block(width: 90%)[
-        #let v-space = v(2em, weak: true)
-        #text(3em)[*#title*]
+  if title != [] {
+    page(
+      align(
+        left + horizon,
+        block(width: 90%)[
+          #let v-space = v(2em, weak: true)
+          #text(3em)[*#title*]
 
-        #v-space
-        #text(1.6em, author)
+          #v-space
+          #text(1.6em, author)
 
-        #if abstract != none {
-          v-space
-          block(width: 80%)[
-            // Default leading is 0.65em.
-            #par(leading: 0.78em, justify: true, linebreaks: "optimized", abstract)
-          ]
-        }
+          #if abstract != none {
+            v-space
+            block(width: 80%)[
+              // Default leading is 0.65em.
+              #par(leading: 0.78em, justify: true, linebreaks: "optimized", abstract)
+            ]
+          }
 
-        #if date != none {
-          v-space
-          text(date.display(date-format))
-        }
-      ],
-    ),
-  )
+          #if date != none {
+            v-space
+            text(date.display(date-format))
+          }
+        ],
+      ),
+    )
+  }
 
   // Configure paragraph properties.
   // Default leading is 0.65em.


### PR DESCRIPTION
A minimal change - but one I end up using more often than not myself.

Simply check whether the document title is empty ( [] ); and if it is, do not generate the title page; akin to how abstract and date disappear if you do not set them.

For one-pagers, where I still want to use `ilm` for, this often comes in handy :)