### PR TITLE
fix: Fix type conflict when there are multiple authors. #31

### DIFF
--- a/lib.typ
+++ b/lib.typ
@@ -110,10 +110,15 @@
       left + horizon,
       block(width: 90%)[
         #let v-space = v(2em, weak: true)
+        #let author-content = if type(author) == array {
+          author.join(linebreak())
+        } else {
+          author
+        }
         #text(3em)[*#title*]
 
         #v-space
-        #text(1.6em, author)
+        #text(1.6em, author-content)
 
         #if abstract != none {
           v-space


### PR DESCRIPTION
<img width="1920" height="1032" alt="image" src="https://github.com/user-attachments/assets/b2bba6f3-41c0-4e04-bf40-05b006f96075" />

Fix the problem mentioned in Issue #31, adjusted the array handling logic of the lib.typ files, all self-tests verified normal.